### PR TITLE
$report in Exception does not provide any valuable information

### DIFF
--- a/Classes/Utility/CustomErrorPageUtility.php
+++ b/Classes/Utility/CustomErrorPageUtility.php
@@ -72,7 +72,7 @@ class CustomErrorPageUtility
             $str404Page = $this->findErrorPage($currentUrl, $configuration, $pageType);
 
             // The errors of GeneralUtility::getUrl gets stored in this variable
-            $report = '';
+            $report = [];
 
             // Call the website. cURL is needed for this.
             $strPageContent = GeneralUtility::getUrl($str404Page, 0, [


### PR DESCRIPTION
thrown Exeception only states "G:G" and no valuable information on the actual cause of the problem.

the reason is $report must be initialized with type array instead of string.