### PR TITLE
[TASK] Add possibility to forward the reason to the error page

### DIFF
--- a/Classes/Utility/ConfigurationUtility.php
+++ b/Classes/Utility/ConfigurationUtility.php
@@ -91,6 +91,9 @@ class ConfigurationUtility
                     $arrayKey => [],
                 ];
 
+                // Forward the reason
+                $domainConfiguration['forward-reason'] = $domain['forward-reason'] === true ?: false;
+
                 foreach ($domain['language-pattern'] as $languageKey => $languageUid) {
                     if ($languageKey === 'default' && $languageUid == true) {
                         // Always prepend default configuration

--- a/Classes/Utility/CustomErrorPageUtility.php
+++ b/Classes/Utility/CustomErrorPageUtility.php
@@ -161,8 +161,9 @@ class CustomErrorPageUtility
                     $this->logger->critical($message);
                 }
 
-                if ($configuration[$hostName]['forward-reason'] === true
-                    || $configuration['_DEFAULT']['forward-reason'] === true) {
+                if (!empty($params['reasonText'])
+                    && ($configuration[$hostName]['forward-reason'] === true
+                        || $configuration['_DEFAULT']['forward-reason'] === true)) {
                     $url .= '&reason=' . urlencode($params['reasonText']);
                 }
 

--- a/Classes/Utility/CustomErrorPageUtility.php
+++ b/Classes/Utility/CustomErrorPageUtility.php
@@ -52,18 +52,18 @@ class CustomErrorPageUtility
      *
      * @throws \Exception
      */
-    public function showCustom404Page(array $param, TypoScriptFrontendController $ref)
+    public function showCustom404Page(array $params, TypoScriptFrontendController $ref)
     {
-        $pageType = $this->getErrorPageType($param);
+        $pageType = $this->getErrorPageType($params);
 
         // TYPO3 handles 403 and 404 HTTP Requests in the same way and we want to separate them
         if ($pageType === self::CODE_403) {
-            $error403Url = $this->getConfigurationErrorPage($param['currentUrl'], $pageType);
+            $error403Url = $this->getConfigurationErrorPage($params['currentUrl'], $pageType);
 
             //Redirect user to the configured 403 page
-            HttpUtility::redirect($error403Url . '&redirect_url=' . urlencode($param['currentUrl']));
+            HttpUtility::redirect($error403Url . '&redirect_url=' . urlencode($params['currentUrl']));
         } else {
-            $this->showCustomErrorPage($param['currentUrl'], $pageType);
+            $this->showCustomErrorPage($params, $pageType);
         }
     }
 
@@ -72,21 +72,21 @@ class CustomErrorPageUtility
      *
      * @throws \Exception
      */
-    public function showCustom503Page(array $param, TypoScriptFrontendController $ref)
+    public function showCustom503Page(array $params, TypoScriptFrontendController $ref)
     {
-        $this->showCustomErrorPage($param['currentUrl'], self::CODE_503);
+        $this->showCustomErrorPage($params, self::CODE_503);
     }
 
     /**
      * Get 403 or 404 error page type(status code) according to given fe_groups
      */
-    protected function getErrorPageType(array $param): int
+    protected function getErrorPageType(array $params): int
     {
         $extConf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['custom_error_page']);
         $force404 = (bool)$extConf['force404'];
 
-        if (!$force404 && isset($param['pageAccessFailureReasons']) && isset($param['pageAccessFailureReasons']['fe_group'])) {
-            return $this->hasUserGroups($param['pageAccessFailureReasons']['fe_group']) ? self::CODE_403 : self::CODE_404;
+        if (!$force404 && isset($params['pageAccessFailureReasons']) && isset($params['pageAccessFailureReasons']['fe_group'])) {
+            return $this->hasUserGroups($params['pageAccessFailureReasons']['fe_group']) ? self::CODE_403 : self::CODE_404;
         }
 
         return self::CODE_404;
@@ -111,11 +111,11 @@ class CustomErrorPageUtility
      *
      * @throws \Exception
      */
-    protected function getConfigurationErrorPage(string $currentUrl, int $pageType): string
+    protected function getConfigurationErrorPage(array $params, int $pageType): string
     {
         $configuration = ConfigurationUtility::loadConfiguration($pageType);
 
-        return $this->findErrorPage($currentUrl, $configuration, $pageType);
+        return $this->findErrorPage($params, $configuration, $pageType);
     }
 
     /**
@@ -125,7 +125,7 @@ class CustomErrorPageUtility
      * @throws \Exception
      * @return mixed
      */
-    private function findErrorPage(string $currentUrl, array $configuration, int $type = self::CODE_404): string
+    private function findErrorPage(array $params, array $configuration, int $type = self::CODE_404): string
     {
         $arrayKey = $type . 'Handling';
         $hostName = GeneralUtility::getIndpEnv('TYPO3_HOST_ONLY');
@@ -142,7 +142,24 @@ class CustomErrorPageUtility
         }
 
         foreach ($configurationAllocations as $regex => $url) {
-            if (preg_match($regex, $currentUrl)) {
+            if (preg_match($regex, $params['currentUrl'])) {
+                $GLOBALS['TSFE']->id = $GLOBALS['TSFE']->domainStartPage;
+                $GLOBALS['TSFE']->getPageAndRootline();
+                $GLOBALS['TSFE']->initTemplate();
+                $GLOBALS['TSFE']->tmpl->start($GLOBALS['TSFE']->rootLine);
+                $GLOBALS['TSFE']->getConfigArray();
+                $GLOBALS['TSFE']->settingLanguage();
+                $GLOBALS['TSFE']->calculateLinkVars();
+
+                if ($GLOBALS['TSFE']->linkVars) {
+                    $url .= $GLOBALS['TSFE']->linkVars;
+                }
+
+                if ($configuration[$hostName]['forward-reason'] === true
+                    || $configuration['_DEFAULT']['forward-reason'] === true) {
+                    $url .= '&reason=' . urlencode($params['reasonText']);
+                }
+
                 return $url;
             }
         }
@@ -154,7 +171,7 @@ class CustomErrorPageUtility
     /**
      * @throws \Exception
      */
-    private function showCustomErrorPage(string $currentUrl, int $pageType)
+    private function showCustomErrorPage(array $params, int $pageType)
     {
         $originalRequestUserAgent = GeneralUtility::getIndpEnv('HTTP_USER_AGENT');
 
@@ -162,12 +179,12 @@ class CustomErrorPageUtility
         if (strpos($originalRequestUserAgent, 'TYPO3/' . $pageType . '-Handling') === false) {
             $originalRequestIp = GeneralUtility::getIndpEnv('REMOTE_ADDR');
             $report = [];
-            $errorUrl = $this->getConfigurationErrorPage($currentUrl, $pageType);
+            $errorUrl = $this->getConfigurationErrorPage($params, $pageType);
 
             // Call the website. cURL is needed for this.
             $pageContent = GeneralUtility::getUrl($errorUrl, 0, [
                 'User-Agent: TYPO3/' . $pageType . '-Handling::' . $originalRequestIp . '::' . $originalRequestUserAgent,
-                'Referer: ' . $currentUrl,
+                'Referer: ' . $params['currentUrl'],
             ], $report);
 
             if ($pageContent === '' || !$pageContent) {

--- a/Classes/Utility/CustomErrorPageUtility.php
+++ b/Classes/Utility/CustomErrorPageUtility.php
@@ -58,7 +58,7 @@ class CustomErrorPageUtility
 
         // TYPO3 handles 403 and 404 HTTP Requests in the same way and we want to separate them
         if ($pageType === self::CODE_403) {
-            $error403Url = $this->getConfigurationErrorPage($params['currentUrl'], $pageType);
+            $error403Url = $this->getConfigurationErrorPage($params, $pageType);
 
             //Redirect user to the configured 403 page
             HttpUtility::redirect($error403Url . '&redirect_url=' . urlencode($params['currentUrl']));

--- a/Classes/Utility/CustomErrorPageUtility.php
+++ b/Classes/Utility/CustomErrorPageUtility.php
@@ -156,7 +156,7 @@ class CustomErrorPageUtility
                         $url .= $GLOBALS['TSFE']->linkVars;
                     }
                 } catch (\Exception $e) {
-                    $message = 'Could not build a localized "pageNotFound" that belongs to this domaine. '
+                    $message = 'Could not build a localized "pageNotFound" that belongs to this domain. '
                         . "(pid: {$GLOBALS['TSFE']->domainStartPage})";
                     $this->logger->critical($message);
                 }

--- a/Classes/Utility/CustomErrorPageUtility.php
+++ b/Classes/Utility/CustomErrorPageUtility.php
@@ -143,22 +143,24 @@ class CustomErrorPageUtility
 
         foreach ($configurationAllocations as $regex => $url) {
             if (preg_match($regex, $params['currentUrl'])) {
-                try {
-                    $GLOBALS['TSFE']->id = $GLOBALS['TSFE']->domainStartPage;
-                    $GLOBALS['TSFE']->getPageAndRootline();
-                    $GLOBALS['TSFE']->initTemplate();
-                    $GLOBALS['TSFE']->tmpl->start($GLOBALS['TSFE']->rootLine);
-                    $GLOBALS['TSFE']->getConfigArray();
-                    $GLOBALS['TSFE']->settingLanguage();
-                    $GLOBALS['TSFE']->calculateLinkVars();
+                if (empty(GeneralUtility::_GP('type'))) {
+                    try {
+                        $GLOBALS['TSFE']->id = $GLOBALS['TSFE']->domainStartPage;
+                        $GLOBALS['TSFE']->getPageAndRootline();
+                        $GLOBALS['TSFE']->initTemplate();
+                        $GLOBALS['TSFE']->tmpl->start($GLOBALS['TSFE']->rootLine);
+                        $GLOBALS['TSFE']->getConfigArray();
+                        $GLOBALS['TSFE']->settingLanguage();
+                        $GLOBALS['TSFE']->calculateLinkVars();
 
-                    if ($GLOBALS['TSFE']->linkVars) {
-                        $url .= $GLOBALS['TSFE']->linkVars;
+                        if ($GLOBALS['TSFE']->linkVars) {
+                            $url .= $GLOBALS['TSFE']->linkVars;
+                        }
+                    } catch (\Exception $e) {
+                        $message = 'Could not build a localized "pageNotFound" that belongs to this domain. '
+                                   . "(pid: {$GLOBALS['TSFE']->domainStartPage})";
+                        $this->logger->critical($message);
                     }
-                } catch (\Exception $e) {
-                    $message = 'Could not build a localized "pageNotFound" that belongs to this domain. '
-                        . "(pid: {$GLOBALS['TSFE']->domainStartPage})";
-                    $this->logger->critical($message);
                 }
 
                 if (!empty($params['reasonText'])

--- a/Classes/Utility/CustomErrorPageUtility.php
+++ b/Classes/Utility/CustomErrorPageUtility.php
@@ -143,16 +143,22 @@ class CustomErrorPageUtility
 
         foreach ($configurationAllocations as $regex => $url) {
             if (preg_match($regex, $params['currentUrl'])) {
-                $GLOBALS['TSFE']->id = $GLOBALS['TSFE']->domainStartPage;
-                $GLOBALS['TSFE']->getPageAndRootline();
-                $GLOBALS['TSFE']->initTemplate();
-                $GLOBALS['TSFE']->tmpl->start($GLOBALS['TSFE']->rootLine);
-                $GLOBALS['TSFE']->getConfigArray();
-                $GLOBALS['TSFE']->settingLanguage();
-                $GLOBALS['TSFE']->calculateLinkVars();
+                try {
+                    $GLOBALS['TSFE']->id = $GLOBALS['TSFE']->domainStartPage;
+                    $GLOBALS['TSFE']->getPageAndRootline();
+                    $GLOBALS['TSFE']->initTemplate();
+                    $GLOBALS['TSFE']->tmpl->start($GLOBALS['TSFE']->rootLine);
+                    $GLOBALS['TSFE']->getConfigArray();
+                    $GLOBALS['TSFE']->settingLanguage();
+                    $GLOBALS['TSFE']->calculateLinkVars();
 
-                if ($GLOBALS['TSFE']->linkVars) {
-                    $url .= $GLOBALS['TSFE']->linkVars;
+                    if ($GLOBALS['TSFE']->linkVars) {
+                        $url .= $GLOBALS['TSFE']->linkVars;
+                    }
+                } catch (\Exception $e) {
+                    $message = 'Could not build a localized "pageNotFound" that belongs to this domaine. '
+                        . "(pid: {$GLOBALS['TSFE']->domainStartPage})";
+                    $this->logger->critical($message);
                 }
 
                 if ($configuration[$hostName]['forward-reason'] === true

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ configuration: &default
     - tld: .bar
     - tld: .foo.bar
   https: true
+  forward-reason: true
 
 
 404: &404
@@ -62,6 +63,7 @@ Contains the configuration array for handling 403, 404 or 503 errors. All keys c
 + <code>pages</code> (array): Contains configuration for pages
 + <code>additional-tlds</code> (array): Contains further TLD for configured domain
 + <code>language-pattern</code> (array): Contains configuration for different languages
++ <code>forward-reason</code> (bool): True if the reason must be forwarded to the error page
 
 #### pages
 The pages array does have to options:

--- a/Resources/Private/Examples/Example.yml
+++ b/Resources/Private/Examples/Example.yml
@@ -14,6 +14,7 @@ configuration: &default
     - tld: .bar
     - tld: .foo.bar
   https: true
+  forward-reason: true
 
 
 404: &404


### PR DESCRIPTION
Hi,
We like your extension and made some improvement to forward the reason to the error page.
Why?! If someone tries to access a page which is not available in his language, he may want to know the page exists in another language and will be able to access it.
We work on a plugin to do it and will make another pull request soon.
Thanks for reading.
Regards